### PR TITLE
Remove mergers and splitters

### DIFF
--- a/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
+++ b/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
@@ -55,7 +55,19 @@ namespace TF3.Core.Converters
             }
 
             NodeContainerFormat result = new NodeContainerFormat();
-            result.Root.Add(new Node(_nodeName, source));
+            Node newNode = new Node(_nodeName);
+
+            if (source is ICloneableFormat)
+            {
+                ICloneableFormat cloneableFormat = source as ICloneableFormat;
+                newNode.ChangeFormat((ICloneableFormat)cloneableFormat.DeepClone());
+            }
+            else
+            {
+                newNode.ChangeFormat(source);
+            }
+
+            result.Root.Add(newNode);
             return result;
         }
     }

--- a/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
+++ b/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
@@ -46,7 +46,15 @@ namespace TF3.Core.Converters
                 throw new FormatException("Node must have 1 children exactly.");
             }
 
-            return source.Root.Children[0].Format;
+            if (source.Root.Children[0].Format is ICloneableFormat)
+            {
+                Node clone = new Node(source.Root.Children[0]);
+                return clone.Format;
+            }
+            else
+            {
+                return source.Root.Children[0].Format;
+            }
         }
     }
 }

--- a/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
+++ b/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
@@ -61,7 +61,8 @@ namespace TF3.Core.Helpers
                     _ = initializer.Invoke(converter, new object[] { parameter.Value });
                 }
 
-                node.ChangeFormat((IFormat)ConvertFormat.With(converter, node.Format));
+                IFormat newFormat = (IFormat)ConvertFormat.With(converter, node.Format);
+                node.ChangeFormat(newFormat);
             }
         }
 
@@ -90,7 +91,8 @@ namespace TF3.Core.Helpers
                 _ = initializer.Invoke(converter, new object[] { translation.Format });
             }
 
-            node.ChangeFormat((IFormat)ConvertFormat.With(converter, node.Format));
+            IFormat newFormat = (IFormat)ConvertFormat.With(converter, node.Format);
+            node.ChangeFormat(newFormat);
         }
     }
 }

--- a/src/Libraries/TF3.Core/Models/AssetInfo.cs
+++ b/src/Libraries/TF3.Core/Models/AssetInfo.cs
@@ -43,17 +43,12 @@ namespace TF3.Core.Models
         public List<AssetFileInfo> Files { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of converters needed to merge the asset files into a single format.
-        /// </summary>
-        public List<ConverterInfo> Mergers { get; set; }
-
-        /// <summary>
         /// Gets or sets the list of converters needed to extract the translatable contents.
         /// </summary>
         public List<ConverterInfo> Extractors { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of converters needed to merge the translation files into a single node format.
+        /// Gets or sets the list of converters needed to merge the translation files.
         /// </summary>
         public List<ConverterInfo> TranslationMergers { get; set; }
 
@@ -61,10 +56,5 @@ namespace TF3.Core.Models
         /// Gets or sets the name of the translator converter.
         /// </summary>
         public string Translator { get; set; }
-
-        /// <summary>
-        /// Gets or sets the list of converters needed to split the asset format into files.
-        /// </summary>
-        public List<ConverterInfo> Splitters { get; set; }
     }
 }


### PR DESCRIPTION
### Description

Remove mergers and splitters from GameScript to simplify the translation workflow
