### PR TITLE
Add DDS default converters

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,10 @@
         <PackageVersion Include="YamlDotNet" Version="9.1.4" />
 
         <PackageVersion Include="EPPlus" Version="5.5.3" />
-
+        <PackageVersion Include="BCnEncoder.Net" Version="2.0.3" />
+        <PackageVersion Include="BCnEncoder.Net.ImageSharp" Version="1.0.4" />
+        <PackageVersion Include="SixLabors.ImageSharp" Version="1.0.3" />
+      
         <PackageVersion Include="nunit" Version="3.12.0" />
         <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.0"/>

--- a/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Converters.DdsImage
+{
+    using System;
+    using BCnEncoder.ImageSharp;
+    using BCnEncoder.Shared;
+    using SixLabors.ImageSharp;
+    using SixLabors.ImageSharp.PixelFormats;
+    using TF3.Core.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// DDS to PNG converter.
+    /// </summary>
+    public class ExtractToPng : IConverter<DdsFileFormat, BinaryFormat>
+    {
+        /// <summary>
+        /// Converts a DDS file into PNG.
+        /// </summary>
+        /// <param name="source">The DDS file.</param>
+        /// <returns>The PNG file.</returns>
+        public BinaryFormat Convert(DdsFileFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var decoder = new BCnEncoder.Decoder.BcDecoder();
+            decoder.OutputOptions.Bc4Component = ColorComponent.Luminance;
+
+            using Image<Rgba32> image = decoder.DecodeToImageRgba32(source.Internal);
+
+            var result = new BinaryFormat();
+            image.SaveAsPng(result.Stream);
+
+            return result;
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToTga.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToTga.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Converters.DdsImage
+{
+    using System;
+    using BCnEncoder.ImageSharp;
+    using BCnEncoder.Shared;
+    using SixLabors.ImageSharp;
+    using SixLabors.ImageSharp.PixelFormats;
+    using TF3.Core.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// DDS to TGA converter.
+    /// </summary>
+    public class ExtractToTga : IConverter<DdsFileFormat, BinaryFormat>
+    {
+        /// <summary>
+        /// Converts a DDS file into TGA.
+        /// </summary>
+        /// <param name="source">The DDS file.</param>
+        /// <returns>The TGA file.</returns>
+        public BinaryFormat Convert(DdsFileFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var decoder = new BCnEncoder.Decoder.BcDecoder();
+            decoder.OutputOptions.Bc4Component = ColorComponent.Luminance;
+
+            using Image<Rgba32> image = decoder.DecodeToImageRgba32(source.Internal);
+
+            var result = new BinaryFormat();
+            image.SaveAsTga(result.Stream);
+
+            return result;
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Converters.DdsImage
+{
+    using System;
+    using BCnEncoder.Shared.ImageFiles;
+    using TF3.Core.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// DDS file reader.
+    /// </summary>
+    public class Reader : IConverter<BinaryFormat, DdsFileFormat>
+    {
+        /// <summary>
+        /// Reads a DDS file.
+        /// </summary>
+        /// <param name="source">The DDS file.</param>
+        /// <returns>The DDS format.</returns>
+        public DdsFileFormat Convert(BinaryFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            DdsFileFormat result = new ();
+            result.Internal = DdsFile.Load(source.Stream);
+
+            return result;
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Converters.DdsImage
+{
+    using System;
+    using BCnEncoder.Encoder;
+    using BCnEncoder.ImageSharp;
+    using BCnEncoder.Shared;
+    using BCnEncoder.Shared.ImageFiles;
+    using SixLabors.ImageSharp;
+    using SixLabors.ImageSharp.PixelFormats;
+    using TF3.Core.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Replaces the original DDS with a new one.
+    /// </summary>
+    public class Replace : IConverter<DdsFileFormat, DdsFileFormat>, IInitializer<BinaryFormat>
+    {
+        private Image<Rgba32> _newImage = null;
+
+        /// <summary>
+        /// Converter initializer.
+        /// </summary>
+        /// <remarks>
+        /// Initialization is mandatory.
+        /// </remarks>
+        /// <param name="parameters">New image binary.</param>
+        public void Initialize(BinaryFormat parameters)
+        {
+            parameters.Stream.Seek(0);
+            _newImage = Image.Load<Rgba32>(parameters.Stream);
+        }
+
+        /// <summary>
+        /// Replaces the original DDS with a new one.
+        /// </summary>
+        /// <param name="source">Original DDS.</param>
+        /// <returns>New DDS.</returns>
+        public DdsFileFormat Convert(DdsFileFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (_newImage == null)
+            {
+                throw new InvalidOperationException("Uninitialized");
+            }
+
+            BcEncoder encoder = new ();
+
+            encoder.OutputOptions.GenerateMipMaps = source.Internal.header.dwMipMapCount > 0;
+            encoder.OutputOptions.Quality = CompressionQuality.Balanced;
+            encoder.OutputOptions.Format = GetCompressionFormat(source.Internal);
+            encoder.OutputOptions.FileFormat = OutputFileFormat.Dds;
+
+            var result = new DdsFileFormat();
+            result.Internal = encoder.EncodeToDds(_newImage);
+
+            return result;
+        }
+
+        private static CompressionFormat GetCompressionFormat(DdsFile dds)
+        {
+            DxgiFormat format;
+            if (dds.header.ddsPixelFormat.IsDxt10Format)
+            {
+                format = dds.dx10Header.dxgiFormat;
+            }
+            else
+            {
+                format = dds.header.ddsPixelFormat.DxgiFormat;
+            }
+
+            return format switch
+            {
+                DxgiFormat.DxgiFormatR32G32B32A32Typeless or DxgiFormat.DxgiFormatR32G32B32A32Float or DxgiFormat.DxgiFormatR32G32B32A32Uint or DxgiFormat.DxgiFormatR32G32B32A32Sint => CompressionFormat.Rgba,
+                DxgiFormat.DxgiFormatR32G32B32Typeless or DxgiFormat.DxgiFormatR32G32B32Float or DxgiFormat.DxgiFormatR32G32B32Uint or DxgiFormat.DxgiFormatR32G32B32Sint => CompressionFormat.Rgb,
+                DxgiFormat.DxgiFormatR16G16B16A16Typeless or DxgiFormat.DxgiFormatR16G16B16A16Float or DxgiFormat.DxgiFormatR16G16B16A16Unorm or DxgiFormat.DxgiFormatR16G16B16A16Uint or DxgiFormat.DxgiFormatR16G16B16A16Snorm or DxgiFormat.DxgiFormatR16G16B16A16Sint => CompressionFormat.Rgba,
+                DxgiFormat.DxgiFormatR32G32Typeless or DxgiFormat.DxgiFormatR32G32Float or DxgiFormat.DxgiFormatR32G32Uint or DxgiFormat.DxgiFormatR32G32Sint => CompressionFormat.Rg,
+                DxgiFormat.DxgiFormatR10G10B10A2Typeless or DxgiFormat.DxgiFormatR10G10B10A2Unorm or DxgiFormat.DxgiFormatR10G10B10A2Uint or DxgiFormat.DxgiFormatR11G11B10Float or DxgiFormat.DxgiFormatR8G8B8A8Typeless or DxgiFormat.DxgiFormatR8G8B8A8Unorm or DxgiFormat.DxgiFormatR8G8B8A8UnormSrgb or DxgiFormat.DxgiFormatR8G8B8A8Uint or DxgiFormat.DxgiFormatR8G8B8A8Snorm or DxgiFormat.DxgiFormatR8G8B8A8Sint => CompressionFormat.Rgba,
+                DxgiFormat.DxgiFormatR16G16Typeless or DxgiFormat.DxgiFormatR16G16Float or DxgiFormat.DxgiFormatR16G16Unorm or DxgiFormat.DxgiFormatR16G16Uint or DxgiFormat.DxgiFormatR16G16Snorm or DxgiFormat.DxgiFormatR16G16Sint => CompressionFormat.Rg,
+                DxgiFormat.DxgiFormatR32Typeless or DxgiFormat.DxgiFormatR32Float or DxgiFormat.DxgiFormatR32Uint or DxgiFormat.DxgiFormatR32Sint => CompressionFormat.R,
+                DxgiFormat.DxgiFormatR24G8Typeless or DxgiFormat.DxgiFormatR8G8Typeless or DxgiFormat.DxgiFormatR8G8Unorm or DxgiFormat.DxgiFormatR8G8Uint or DxgiFormat.DxgiFormatR8G8Snorm or DxgiFormat.DxgiFormatR8G8Sint => CompressionFormat.Rg,
+                DxgiFormat.DxgiFormatR16Typeless or DxgiFormat.DxgiFormatR16Float or DxgiFormat.DxgiFormatR16Unorm or DxgiFormat.DxgiFormatR16Uint or DxgiFormat.DxgiFormatR16Snorm or DxgiFormat.DxgiFormatR16Sint or DxgiFormat.DxgiFormatR8Typeless or DxgiFormat.DxgiFormatR8Unorm or DxgiFormat.DxgiFormatR8Uint or DxgiFormat.DxgiFormatR8Snorm or DxgiFormat.DxgiFormatR8Sint => CompressionFormat.R,
+                DxgiFormat.DxgiFormatBc1Typeless or DxgiFormat.DxgiFormatBc1Unorm or DxgiFormat.DxgiFormatBc1UnormSrgb => CompressionFormat.Bc1,
+                DxgiFormat.DxgiFormatBc2Typeless or DxgiFormat.DxgiFormatBc2Unorm or DxgiFormat.DxgiFormatBc2UnormSrgb => CompressionFormat.Bc2,
+                DxgiFormat.DxgiFormatBc3Typeless or DxgiFormat.DxgiFormatBc3Unorm or DxgiFormat.DxgiFormatBc3UnormSrgb => CompressionFormat.Bc3,
+                DxgiFormat.DxgiFormatBc4Typeless or DxgiFormat.DxgiFormatBc4Unorm or DxgiFormat.DxgiFormatBc4Snorm => CompressionFormat.Bc4,
+                DxgiFormat.DxgiFormatBc5Typeless or DxgiFormat.DxgiFormatBc5Unorm or DxgiFormat.DxgiFormatBc5Snorm => CompressionFormat.Bc5,
+                DxgiFormat.DxgiFormatB5G5R5A1Unorm or DxgiFormat.DxgiFormatB8G8R8A8Unorm or DxgiFormat.DxgiFormatB8G8R8A8Typeless or DxgiFormat.DxgiFormatB8G8R8A8UnormSrgb => CompressionFormat.Bgra,
+                DxgiFormat.DxgiFormatBc6HTypeless or DxgiFormat.DxgiFormatBc6HUf16 or DxgiFormat.DxgiFormatBc6HSf16 => CompressionFormat.Bc6,
+                DxgiFormat.DxgiFormatBc7Typeless or DxgiFormat.DxgiFormatBc7Unorm or DxgiFormat.DxgiFormatBc7UnormSrgb => CompressionFormat.Bc7,
+                DxgiFormat.DxgiFormatAtcExt => CompressionFormat.Atc,
+                DxgiFormat.DxgiFormatAtcExplicitAlphaExt => CompressionFormat.AtcExplicitAlpha,
+                DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt => CompressionFormat.AtcInterpolatedAlpha,
+                _ => throw new FormatException($"Unknown DxgiFormat: {format}"),
+            };
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Writer.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Writer.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Converters.DdsImage
+{
+    using System;
+    using TF3.Core.Formats;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// DDS file writer.
+    /// </summary>
+    public class Writer : IConverter<DdsFileFormat, BinaryFormat>
+    {
+        /// <summary>
+        /// Writes a DDS file.
+        /// </summary>
+        /// <param name="source">The DDS format.</param>
+        /// <returns>The DDS file.</returns>
+        public BinaryFormat Convert(DdsFileFormat source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var result = new BinaryFormat();
+            source.Internal.Write(result.Stream);
+            return result;
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Formats/DdsFileFormat.cs
+++ b/src/Libraries/TF3.Core/Formats/DdsFileFormat.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace TF3.Core.Formats
+{
+    using BCnEncoder.Shared.ImageFiles;
+    using Yarhl.FileFormat;
+
+    /// <summary>
+    /// IFormat wrapper for BCnEncoder.Shared.ImageFiles.DdsFile.
+    /// </summary>
+    public class DdsFileFormat : IFormat
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DdsFileFormat"/> class.
+        /// </summary>
+        public DdsFileFormat()
+        {
+            Internal = null;
+        }
+
+        /// <summary>
+        /// Gets or sets the DdsFile.
+        /// </summary>
+        public DdsFile Internal { get; set; }
+    }
+}

--- a/src/Libraries/TF3.Core/TF3.Core.csproj
+++ b/src/Libraries/TF3.Core/TF3.Core.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Yarhl.Media" />
     <PackageReference Include="Standart.Hash.xxHash" />
     <PackageReference Include="YamlDotNet" />
+    <PackageReference Include="BCnEncoder.Net" />
+    <PackageReference Include="BCnEncoder.Net.ImageSharp" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

Converters for DDS images to/from TGA and PNG.

Uses [BCnEncoder.NET](https://github.com/Nominom/BCnEncoder.NET) and [ImageSharp](https://github.com/SixLabors/ImageSharp).
