### PR TITLE
Multi file containers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,20 @@
 MIT License
 
-Copyright (c) 2021 Kaplas
+Copyright (c) 2022 Kaplas
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,9 +4,7 @@
         "src": [
           {
             "files": [
-              "Libraries/TF3.Core/TF3.Core.csproj",
-              "YarhlPlugins/TF3.YarhlPlugin.YakuzaCommon/TF3.YarhlPlugin.YakuzaCommon.csproj",
-              "YarhlPlugins/TF3.YarhlPlugin.YakuzaKiwami2/TF3.YarhlPlugin.YakuzaKiwami2.csproj"
+              "Libraries/TF3.Core/TF3.Core.csproj"
             ],
             "src": "../src"
           }

--- a/docs/global_metadata.json
+++ b/docs/global_metadata.json
@@ -1,6 +1,6 @@
 {
     "_appTitle": "Translation Framework v3",
-    "_appFooter": "Copyright (c) 2021 Kaplas",
+    "_appFooter": "Copyright (c) 2022 Kaplas",
     "_appLogoPath": "images/logo_48.png",
     "_appFaviconPath": "images/favicon.png",
     "_enableSearch": true,

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="PleOps Preview" value="https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -12,113 +12,6 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-# Standard properties
-end_of_line = lf
-max_line_length = 0
-
-# Microsoft .NET properties
-csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
-csharp_style_expression_bodied_constructors = true:none
-csharp_style_expression_bodied_methods = true:none
-csharp_style_var_elsewhere = false:none
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:none
-csharp_using_directive_placement = inside_namespace:silent
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.import_to_resharper = True
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.resharper_description = camel_case_for_private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.resharper_guid = 45dc9734-87f9-4b55-9b3c-e21310ba37a8
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.severity = suggestion
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.style = lower_camel_case_style
-dotnet_naming_rule.camel_case_for_private_internal_fields_rule.symbols = camel_case_for_private_internal_fields_symbols
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.import_to_resharper = True
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.resharper_description = constant_fields_should_be_pascal_case
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.resharper_guid = d2dfa405-9a9a-4a95-b582-7ee9c691376d
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.style = upper_camel_case_style
-dotnet_naming_rule.constant_fields_should_be_pascal_case_rule.symbols = constant_fields_should_be_pascal_case_symbols
-dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_constants_rule.resharper_style = _ + aaBb, AaBb
-dotnet_naming_rule.private_constants_rule.severity = suggestion
-dotnet_naming_rule.private_constants_rule.style = lower_camel_case_style
-dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
-dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_static_fields_rule.resharper_style = _ + aaBb, s_ + aaBb
-dotnet_naming_rule.private_static_fields_rule.severity = suggestion
-dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
-dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
-dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_static_readonly_rule.resharper_style = _ + aaBb, s_ + aaBb
-dotnet_naming_rule.private_static_readonly_rule.severity = suggestion
-dotnet_naming_rule.private_static_readonly_rule.style = lower_camel_case_style
-dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
-dotnet_naming_rule.static_fields_should_have_prefix_rule.import_to_resharper = True
-dotnet_naming_rule.static_fields_should_have_prefix_rule.resharper_description = static_fields_should_have_prefix
-dotnet_naming_rule.static_fields_should_have_prefix_rule.resharper_guid = 6ef6ae07-8cf2-49fa-9340-52dcefcef353
-dotnet_naming_rule.static_fields_should_have_prefix_rule.severity = suggestion
-dotnet_naming_rule.static_fields_should_have_prefix_rule.style = s_lower_camel_case_style
-dotnet_naming_rule.static_fields_should_have_prefix_rule.symbols = static_fields_should_have_prefix_symbols
-dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
-dotnet_naming_style.lower_camel_case_style.required_prefix = _
-dotnet_naming_style.s_lower_camel_case_style.capitalization = camel_case
-dotnet_naming_style.s_lower_camel_case_style.required_prefix = s_
-dotnet_naming_style.upper_camel_case_style.capitalization = pascal_case
-dotnet_naming_symbols.camel_case_for_private_internal_fields_symbols.applicable_accessibilities = local,internal,private
-dotnet_naming_symbols.camel_case_for_private_internal_fields_symbols.applicable_kinds = field
-dotnet_naming_symbols.camel_case_for_private_internal_fields_symbols.resharper_applicable_kinds = any_field
-dotnet_naming_symbols.camel_case_for_private_internal_fields_symbols.resharper_required_modifiers = any
-dotnet_naming_symbols.constant_fields_should_be_pascal_case_symbols.applicable_accessibilities = local,public,internal,private,protected,protected_internal,private_protected
-dotnet_naming_symbols.constant_fields_should_be_pascal_case_symbols.applicable_kinds = field
-dotnet_naming_symbols.constant_fields_should_be_pascal_case_symbols.required_modifiers = const
-dotnet_naming_symbols.constant_fields_should_be_pascal_case_symbols.resharper_applicable_kinds = constant_field
-dotnet_naming_symbols.constant_fields_should_be_pascal_case_symbols.resharper_required_modifiers = any
-dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
-dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
-dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
-dotnet_naming_symbols.static_fields_should_have_prefix_symbols.applicable_accessibilities = local,internal,private,private_protected
-dotnet_naming_symbols.static_fields_should_have_prefix_symbols.applicable_kinds = field
-dotnet_naming_symbols.static_fields_should_have_prefix_symbols.required_modifiers = static
-dotnet_naming_symbols.static_fields_should_have_prefix_symbols.resharper_applicable_kinds = any_field
-dotnet_naming_symbols.static_fields_should_have_prefix_symbols.resharper_required_modifiers = static
-dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
-dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:none
-dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-dotnet_style_qualification_for_event = false:suggestion
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
-file_header_template = Copyright (c) 2021 Kaplas\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.
-
-# ReSharper properties
-resharper_braces_for_for = required
-resharper_braces_for_foreach = required
-resharper_braces_for_ifelse = required
-resharper_braces_for_while = required
-resharper_braces_redundant = false
-resharper_csharp_case_block_braces = next_line_shifted_2
-resharper_enforce_line_ending_style = true
-resharper_keep_existing_initializer_arrangement = false
-resharper_qualified_using_at_nested_scope = true
-resharper_use_indent_from_vs = false
-
-# ReSharper inspection severities
-resharper_arrange_accessor_owner_body_highlighting = none
-resharper_arrange_redundant_parentheses_highlighting = hint
-resharper_arrange_type_member_modifiers_highlighting = hint
-resharper_arrange_type_modifiers_highlighting = hint
-resharper_inconsistent_naming_highlighting = suggestion
-resharper_web_config_module_not_resolved_highlighting = warning
-resharper_web_config_type_not_resolved_highlighting = warning
-resharper_web_config_wrong_module_highlighting = warning
-
 [project.json]
 indent_size = 2
 
@@ -129,6 +22,7 @@ generated_code = true
 # C# files
 [*.cs]
 end_of_line = lf
+dotnet_diagnostic.IDE0090.severity = silent
 
 # New line preferences
 csharp_new_line_before_open_brace = all
@@ -143,7 +37,7 @@ csharp_new_line_between_query_expression_clauses = true
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
@@ -157,25 +51,25 @@ dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # static fields should have s_ prefix
 dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
-dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
-dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 dotnet_naming_style.static_prefix_style.required_prefix = s_
@@ -183,8 +77,8 @@ dotnet_naming_style.static_prefix_style.capitalization = camel_case
 
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
@@ -272,16 +166,16 @@ dotnet_code_quality.ca1822.api_surface = private, internal
 dotnet_code_quality.ca2208.api_surface = public
 
 # SA1633: File should have header
-dotnet_diagnostic.sa1633.severity = none
+dotnet_diagnostic.SA1633.severity = none
 
 # SA1101: Prefix local calls with this
-dotnet_diagnostic.sa1101.severity = none
+dotnet_diagnostic.SA1101.severity = none
 
 # SA1309: Field names should not begin with underscore
-dotnet_diagnostic.sa1309.severity = none
+dotnet_diagnostic.SA1309.severity = none
 
 # License header
-file_header_template = Copyright (c) 2021 Kaplas\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.
+file_header_template = Copyright (c) 2022 Kaplas\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.
 
 # C++ Files
 [*.{cpp,h,in}]
@@ -318,20 +212,15 @@ end_of_line = lf
 end_of_line = crlf
 
 # Special rules for test projects
-[Tests/**/*.cs]
-dotnet_diagnostic.cs1591.severity = none # Disable documentation
-dotnet_diagnostic.ca1001.severity = none # No need to implement IDisposable in test classes with cleanup.
-dotnet_diagnostic.ca1034.severity = none # Public types in test classes for testing implementations
-dotnet_diagnostic.ca1040.severity = none # Empty interfaces for testing
-dotnet_diagnostic.ca1062.severity = none # No need to validate args in test methods
-dotnet_diagnostic.ca1305.severity = none # No culture method for quick test code
-dotnet_diagnostic.ca1307.severity = none # No culture method for quick test code
-dotnet_diagnostic.sa0001.severity = none # Disable documentation
-dotnet_diagnostic.sa1600.severity = none # Disable documentation
-dotnet_diagnostic.s2699.severity = none # Assert may be in helper methods
-dotnet_diagnostic.s3966.severity = none # Dispose twice to test implementation
-
-[*.{appxmanifest,asax,ascx,aspx,axaml,build,cg,cginc,compute,cs,cshtml,dtd,hlsl,hlsli,hlslinc,master,nuspec,paml,razor,resw,resx,skin,usf,ush,vb,xaml,xamlx,xoml,xsd}]
-indent_style = space
-indent_size = 4
-tab_width = 4
+[*Tests**]
+dotnet_diagnostic.CS1591.severity = none # Disable documentation
+dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
+dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations
+dotnet_diagnostic.CA1040.severity = none # Empty interfaces for testing
+dotnet_diagnostic.CA1062.severity = none # No need to validate args in test methods
+dotnet_diagnostic.CA1305.severity = none # No culture method for quick test code
+dotnet_diagnostic.CA1307.severity = none # No culture method for quick test code
+dotnet_diagnostic.SA0001.severity = none # Disable documentation
+dotnet_diagnostic.SA1600.severity = none # Disable documentation
+dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
+dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation

--- a/src/Apps/TF3.CommandLine/Options/ExtractOptions.cs
+++ b/src/Apps/TF3.CommandLine/Options/ExtractOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Apps/TF3.CommandLine/Options/ListScriptsOptions.cs
+++ b/src/Apps/TF3.CommandLine/Options/ListScriptsOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Apps/TF3.CommandLine/Options/RebuildOptions.cs
+++ b/src/Apps/TF3.CommandLine/Options/RebuildOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Apps/TF3.CommandLine/Program.cs
+++ b/src/Apps/TF3.CommandLine/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
         <Product>Translation Framework 3</Product>
         <Authors>Kaplas</Authors>
         <Company>None</Company>
-        <Copyright>Copyright (C) 2021 Kaplas</Copyright>
+        <Copyright>Copyright (c) 2022 Kaplas</Copyright>
 
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 

--- a/src/Libraries/TF3.Core/Converters/BinaryPatch/Apply.cs
+++ b/src/Libraries/TF3.Core/Converters/BinaryPatch/Apply.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/BinaryPatch/Reader.cs
+++ b/src/Libraries/TF3.Core/Converters/BinaryPatch/Reader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
@@ -46,7 +46,7 @@ namespace TF3.Core.Converters.DdsImage
                 throw new ArgumentNullException(nameof(source));
             }
 
-            BCnEncoder.Decoder.BcDecoder decoder = new ()
+            var decoder = new BCnEncoder.Decoder.BcDecoder()
             {
                 OutputOptions =
                 {

--- a/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToPng.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToTga.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/ExtractToTga.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Reader.cs
@@ -44,7 +44,7 @@ namespace TF3.Core.Converters.DdsImage
             }
 
             source.Stream.Seek(0);
-            DdsFileFormat result = new ()
+            var result = new DdsFileFormat()
             {
                 Internal = DdsFile.Load(source.Stream),
             };

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
@@ -69,7 +69,7 @@ namespace TF3.Core.Converters.DdsImage
                 throw new InvalidOperationException("Uninitialized");
             }
 
-            BcEncoder encoder = new ()
+            var encoder = new BcEncoder()
             {
                 OutputOptions =
                 {
@@ -80,7 +80,7 @@ namespace TF3.Core.Converters.DdsImage
                 },
             };
 
-            DdsFileFormat result = new ()
+            var result = new DdsFileFormat()
             {
                 Internal = encoder.EncodeToDds(_newImage),
             };

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Replace.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/DdsImage/Writer.cs
+++ b/src/Libraries/TF3.Core/Converters/DdsImage/Writer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/FormatReplace.cs
+++ b/src/Libraries/TF3.Core/Converters/FormatReplace.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
+++ b/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
+++ b/src/Libraries/TF3.Core/Converters/FormatToSingleNode.cs
@@ -54,8 +54,8 @@ namespace TF3.Core.Converters
                 _nodeName = "single_node";
             }
 
-            NodeContainerFormat result = new ();
-            Node newNode = new (_nodeName);
+            var result = new NodeContainerFormat();
+            var newNode = new Node(_nodeName);
 
             if (source is ICloneableFormat cloneableFormat)
             {

--- a/src/Libraries/TF3.Core/Converters/Po/NodeContainerToPo.cs
+++ b/src/Libraries/TF3.Core/Converters/Po/NodeContainerToPo.cs
@@ -41,7 +41,7 @@ namespace TF3.Core.Converters.Po
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Yarhl.Media.Text.Po po = new ();
+            var po = new Yarhl.Media.Text.Po();
 
             foreach (Node part in source.Root.Children)
             {

--- a/src/Libraries/TF3.Core/Converters/Po/NodeContainerToPo.cs
+++ b/src/Libraries/TF3.Core/Converters/Po/NodeContainerToPo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
+++ b/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
+++ b/src/Libraries/TF3.Core/Converters/SingleNodeToFormat.cs
@@ -48,7 +48,7 @@ namespace TF3.Core.Converters
 
             if (source.Root.Children[0].Format is ICloneableFormat)
             {
-                Node clone = new (source.Root.Children[0]);
+                var clone = new Node(source.Root.Children[0]);
                 return clone.Format;
             }
             else

--- a/src/Libraries/TF3.Core/EventArgs/AssetEventArgs.cs
+++ b/src/Libraries/TF3.Core/EventArgs/AssetEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/EventArgs/ContainerEventArgs.cs
+++ b/src/Libraries/TF3.Core/EventArgs/ContainerEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/EventArgs/PatchEventArgs.cs
+++ b/src/Libraries/TF3.Core/EventArgs/PatchEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/EventArgs/ScriptEventArgs.cs
+++ b/src/Libraries/TF3.Core/EventArgs/ScriptEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Exceptions/ByteMismatchException.cs
+++ b/src/Libraries/TF3.Core/Exceptions/ByteMismatchException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Exceptions/ChecksumMismatchException.cs
+++ b/src/Libraries/TF3.Core/Exceptions/ChecksumMismatchException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Exceptions/UnknownConverterException.cs
+++ b/src/Libraries/TF3.Core/Exceptions/UnknownConverterException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Formats/BinaryPatch.cs
+++ b/src/Libraries/TF3.Core/Formats/BinaryPatch.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Formats/DdsFileFormat.cs
+++ b/src/Libraries/TF3.Core/Formats/DdsFileFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/GameScript.cs
+++ b/src/Libraries/TF3.Core/GameScript.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/GameScript.cs
+++ b/src/Libraries/TF3.Core/GameScript.cs
@@ -168,7 +168,7 @@ namespace TF3.Core
             ScriptExtracting?.Invoke(this, new ScriptEventArgs(this));
             Directory.CreateDirectory(outputPath);
 
-            Dictionary<string, Node> containersDict = new ();
+            var containersDict = new Dictionary<string, Node>();
 
             Node gameRoot = NodeFactory.FromDirectory(gamePath, "*", "root", true, Yarhl.IO.FileOpenMode.Read);
             containersDict.Add("root", gameRoot);
@@ -201,7 +201,7 @@ namespace TF3.Core
             ScriptRebuilding?.Invoke(this, new ScriptEventArgs(this));
             Directory.CreateDirectory(outputPath);
 
-            Dictionary<string, Node> containersDict = new ();
+            var containersDict = new Dictionary<string, Node>();
             Node gameRoot = NodeFactory.FromDirectory(gamePath, "*", "root", true, Yarhl.IO.FileOpenMode.Read);
             containersDict.Add("root", gameRoot);
 
@@ -379,7 +379,7 @@ namespace TF3.Core
                 Node file = ReadFile(fileInfo, containers);
 
                 // Add call will remove the node from its original parent, so we need to make a copy
-                Node newFile = new (file);
+                var newFile = new Node(file);
                 newFile.Transform(fileInfo.Readers, Parameters);
                 asset.Add(newFile);
             }

--- a/src/Libraries/TF3.Core/Helpers/ChecksumHelper.cs
+++ b/src/Libraries/TF3.Core/Helpers/ChecksumHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Helpers/ChecksumHelper.cs
+++ b/src/Libraries/TF3.Core/Helpers/ChecksumHelper.cs
@@ -69,7 +69,7 @@ namespace TF3.Core.Helpers
         /// <returns>The checksum value.</returns>
         private static ulong Calculate(string file)
         {
-            using FileStream s = new (file, FileMode.Open, FileAccess.Read);
+            using var s = new FileStream(file, FileMode.Open, FileAccess.Read);
             return Calculate(s);
         }
 

--- a/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
+++ b/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
+++ b/src/Libraries/TF3.Core/Helpers/YarhlNodeExtension.cs
@@ -58,7 +58,7 @@ namespace TF3.Core.Helpers
                 if (parameter != null)
                 {
                     string json = parameter.Value.GetRawText();
-                    Type parameterType = Type.GetType(parameter.TypeName);
+                    var parameterType = Type.GetType(parameter.TypeName);
                     if (parameterType != null)
                     {
                         object value = JsonSerializer.Deserialize(json, parameterType);
@@ -91,7 +91,7 @@ namespace TF3.Core.Helpers
 
         private static void ApplyChange(this Node node, ConverterMetadata metadata, object[] parameters)
         {
-            IConverter converter = (IConverter)Activator.CreateInstance(metadata.Type);
+            var converter = (IConverter)Activator.CreateInstance(metadata.Type);
 
             System.Reflection.MethodInfo initializer = metadata.Type.GetMethod("Initialize");
 
@@ -100,7 +100,7 @@ namespace TF3.Core.Helpers
                 _ = initializer.Invoke(converter, parameters);
             }
 
-            IFormat newFormat = (IFormat)ConvertFormat.With(converter, node.Format);
+            var newFormat = (IFormat)ConvertFormat.With(converter, node.Format);
             node.ChangeFormat(newFormat);
         }
     }

--- a/src/Libraries/TF3.Core/Models/AssetFileInfo.cs
+++ b/src/Libraries/TF3.Core/Models/AssetFileInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/AssetInfo.cs
+++ b/src/Libraries/TF3.Core/Models/AssetInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/ContainerInfo.cs
+++ b/src/Libraries/TF3.Core/Models/ContainerInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/ContainerInfo.cs
+++ b/src/Libraries/TF3.Core/Models/ContainerInfo.cs
@@ -40,15 +40,15 @@ namespace TF3.Core.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the container path.
+        /// Gets or sets the container paths.
         /// </summary>
-        public string Path { get; set; }
+        public List<string> Paths { get; set; }
 
         /// <summary>
-        /// Gets or sets the container checksum.
-        /// If it is 0, it won't be checked.
+        /// Gets or sets the container checksums.
+        /// If it is 0, the file won't be checked.
         /// </summary>
-        public ulong Checksum { get; set; }
+        public List<ulong> Checksums { get; set; }
 
         /// <summary>
         /// Gets or sets the list of converters needed to read the container.

--- a/src/Libraries/TF3.Core/Models/ConverterInfo.cs
+++ b/src/Libraries/TF3.Core/Models/ConverterInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/FileInfo.cs
+++ b/src/Libraries/TF3.Core/Models/FileInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/ParameterInfo.cs
+++ b/src/Libraries/TF3.Core/Models/ParameterInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/Models/PatchInfo.cs
+++ b/src/Libraries/TF3.Core/Models/PatchInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Libraries/TF3.Core/ScriptManager.cs
+++ b/src/Libraries/TF3.Core/ScriptManager.cs
@@ -31,7 +31,7 @@ namespace TF3.Core
     /// </summary>
     public static class ScriptManager
     {
-        private static List<GameScript> _scripts = new ();
+        private static readonly List<GameScript> _scripts = new List<GameScript>();
 
         /// <summary>
         /// Gets a list of loaded scripts.

--- a/src/Libraries/TF3.Core/ScriptManager.cs
+++ b/src/Libraries/TF3.Core/ScriptManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kaplas
+// Copyright (c) 2022 Kaplas
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/Tests/TF3.Tests/ChecksumHelperTests.cs
+++ b/src/Tests/TF3.Tests/ChecksumHelperTests.cs
@@ -45,7 +45,7 @@ namespace TF3.Tests
         [Test]
         public void CheckStream()
         {
-            using MemoryStream stream = new (Encoding.ASCII.GetBytes(TestData));
+            using var stream = new MemoryStream(Encoding.ASCII.GetBytes(TestData));
             bool result = ChecksumHelper.Check(stream, 0x5AB1599F68E64610);
             Assert.IsTrue(result);
             result = ChecksumHelper.Check(stream, 0x01);
@@ -66,7 +66,7 @@ namespace TF3.Tests
             File.WriteAllText(filePath, TestData);
             Assert.IsTrue(ChecksumHelper.Check(filePath, 0x00));
 
-            using MemoryStream stream = new (Encoding.ASCII.GetBytes(TestData));
+            using var stream = new MemoryStream(Encoding.ASCII.GetBytes(TestData));
             Assert.IsTrue(ChecksumHelper.Check(stream, 0x00));
         }
     }

--- a/src/Tests/TF3.Tests/Converters/BinaryPatch/ApplyTests.cs
+++ b/src/Tests/TF3.Tests/Converters/BinaryPatch/ApplyTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            Apply converter = new ();
+            var converter = new Apply();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
@@ -22,8 +22,8 @@
         public void UninitializedConverterThrowsException()
         {
             using DataStream ds = DataStreamFactory.FromArray(_testData, 0, _testData.Length);
-            using BinaryFormat format = new (ds);
-            Apply converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Apply();
 
             _ = Assert.Throws<InvalidOperationException>(() => converter.Convert(format));
         }
@@ -31,7 +31,7 @@
         [Test]
         public void MismatchByteThrowsException()
         {
-            BinaryPatch patch = new ()
+            var patch = new BinaryPatch()
             {
                 FileName = "test.exe",
                 RawOffset = 0,
@@ -39,8 +39,8 @@
             patch.Patches.Add((4, 0x21, 0x30));
 
             using DataStream ds = DataStreamFactory.FromArray(_testData, 0, _testData.Length);
-            using BinaryFormat format = new (ds);
-            Apply converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Apply();
             converter.Initialize(patch);
             _ = Assert.Throws<ByteMismatchException>(() => converter.Convert(format));
         }
@@ -48,7 +48,7 @@
         [Test]
         public void ApplyPatchWithoutOffset()
         {
-            BinaryPatch patch = new ()
+            var patch = new BinaryPatch()
             {
                 FileName = "test.exe",
                 RawOffset = 0,
@@ -56,12 +56,12 @@
             patch.Patches.Add((4, 0x20, 0x30));
 
             using DataStream ds = DataStreamFactory.FromArray(_testData, 0, _testData.Length);
-            using BinaryFormat format = new (ds);
-            Apply converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Apply();
             converter.Initialize(patch);
             converter.Convert(format);
 
-            DataReader reader = new (ds);
+            var reader = new DataReader(ds);
             ds.Position = 4;
 
             byte changedByte = reader.ReadByte();
@@ -71,7 +71,7 @@
         [Test]
         public void ApplyPatchWithOffset()
         {
-            BinaryPatch patch = new ()
+            var patch = new BinaryPatch()
             {
                 FileName = "test.exe",
                 RawOffset = 3,
@@ -79,12 +79,12 @@
             patch.Patches.Add((4, 0x72, 0x62));
 
             using DataStream ds = DataStreamFactory.FromArray(_testData, 0, _testData.Length);
-            using BinaryFormat format = new (ds);
-            Apply converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Apply();
             converter.Initialize(patch);
             converter.Convert(format);
 
-            DataReader reader = new (ds);
+            var reader = new DataReader(ds);
             ds.Position = 7; // 4 + 3
 
             byte changedByte = reader.ReadByte();

--- a/src/Tests/TF3.Tests/Converters/BinaryPatch/ReaderTests.cs
+++ b/src/Tests/TF3.Tests/Converters/BinaryPatch/ReaderTests.cs
@@ -11,7 +11,7 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            Reader converter = new ();
+            var converter = new Reader();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
@@ -19,10 +19,10 @@
         public void NoFileNameThrowsException()
         {
             const string patch = "0000000000123456:01->02";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             _ = Assert.Throws<FormatException>(() => converter.Convert(textFormat));
         }
 
@@ -30,10 +30,10 @@
         public void NoPatchesThrowsException()
         {
             const string patch = ";Test\n>test.exe";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             _ = Assert.Throws<FormatException>(() => converter.Convert(textFormat));
         }
 
@@ -41,10 +41,10 @@
         public void UninitializedConverter()
         {
             const string patch = ">test.exe\n0000000000123456:01->02";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             BinaryPatch result = converter.Convert(textFormat);
 
             Assert.IsNotNull(result);
@@ -60,10 +60,10 @@
         public void InitializedConverter()
         {
             const string patch = ">test.exe\n0000000000123456:01->02";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             converter.Initialize(1000);
             BinaryPatch result = converter.Convert(textFormat);
 
@@ -80,10 +80,10 @@
         public void ReadEmptyStrings()
         {
             const string patch = ">test.exe\n    \n0000000000123456:01->02";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             BinaryPatch result = converter.Convert(textFormat);
 
             Assert.IsNotNull(result);
@@ -98,10 +98,10 @@
         public void ReadComments()
         {
             const string patch = ";This is a comment\n>test.exe\n0000000000123456:01->02;This is an inlined comment\n;This is another comment";
-            using BinaryFormat textFormat = new ();
+            using var textFormat = new BinaryFormat();
             new TextDataWriter(textFormat.Stream).Write(patch);
 
-            Reader converter = new ();
+            var converter = new Reader();
             BinaryPatch result = converter.Convert(textFormat);
 
             Assert.IsNotNull(result);

--- a/src/Tests/TF3.Tests/Converters/DdsImage/ExtractToPngTests.cs
+++ b/src/Tests/TF3.Tests/Converters/DdsImage/ExtractToPngTests.cs
@@ -14,15 +14,15 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            ExtractToPng converter = new ();
+            var converter = new ExtractToPng();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
         [Test]
         public void NullDdsThrowsException()
         {
-            ExtractToPng converter = new ();
-            DdsFileFormat format = new ();
+            var converter = new ExtractToPng();
+            var format = new DdsFileFormat();
             _ = Assert.Throws<NullReferenceException>(() => converter.Convert(format));
         }
 
@@ -30,19 +30,19 @@
         public void Export()
         {
             using DataStream ds = DataStreamFactory.FromArray(_validData, 0, _validData.Length);
-            DdsFileFormat format = new ()
+            var format = new DdsFileFormat()
             {
                 Internal = DdsFile.Load(ds),
             };
 
-            ExtractToPng converter = new ();
+            var converter = new ExtractToPng();
 
             BinaryFormat result = converter.Convert(format);
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.Stream);
 
             result.Stream.Position = 0;
-            DataReader reader = new (result.Stream);
+            var reader = new DataReader(result.Stream);
             ulong magic = reader.ReadUInt64();
 
             Assert.AreEqual(727905341920923785, magic);

--- a/src/Tests/TF3.Tests/Converters/DdsImage/ExtractToTgaTests.cs
+++ b/src/Tests/TF3.Tests/Converters/DdsImage/ExtractToTgaTests.cs
@@ -14,15 +14,15 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            ExtractToTga converter = new ();
+            var converter = new ExtractToTga();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
         [Test]
         public void NullDdsThrowsException()
         {
-            ExtractToTga converter = new ();
-            DdsFileFormat format = new ();
+            var converter = new ExtractToTga();
+            var format = new DdsFileFormat();
             _ = Assert.Throws<NullReferenceException>(() => converter.Convert(format));
         }
 
@@ -30,9 +30,9 @@
         public void Export()
         {
             using DataStream ds = DataStreamFactory.FromArray(_validData, 0, _validData.Length);
-            DdsFileFormat format = new () { Internal = DdsFile.Load(ds) };
+            var format = new DdsFileFormat() { Internal = DdsFile.Load(ds) };
 
-            ExtractToTga converter = new ();
+            var converter = new ExtractToTga();
 
             // TGA files do not have any magic number, so we can only check if no exception has been thrown
             BinaryFormat result = null;

--- a/src/Tests/TF3.Tests/Converters/DdsImage/ReaderTests.cs
+++ b/src/Tests/TF3.Tests/Converters/DdsImage/ReaderTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            Reader converter = new ();
+            var converter = new Reader();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
@@ -22,8 +22,8 @@
         public void InvalidDdsThrowsException()
         {
             using DataStream ds = DataStreamFactory.FromArray(_invalidData, 0, _invalidData.Length);
-            using BinaryFormat format = new (ds);
-            Reader converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Reader();
 
             _ = Assert.Throws<FormatException>(() => converter.Convert(format));
         }
@@ -32,8 +32,8 @@
         public void ReadDds()
         {
             using DataStream ds = DataStreamFactory.FromArray(_validData, 0, _validData.Length);
-            using BinaryFormat format = new (ds);
-            Reader converter = new ();
+            using var format = new BinaryFormat(ds);
+            var converter = new Reader();
 
             DdsFileFormat result = converter.Convert(format);
             Assert.IsNotNull(result);

--- a/src/Tests/TF3.Tests/Converters/DdsImage/ReplaceTests.cs
+++ b/src/Tests/TF3.Tests/Converters/DdsImage/ReplaceTests.cs
@@ -16,7 +16,7 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            Replace converter = new ();
+            var converter = new Replace();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
@@ -24,12 +24,12 @@
         public void UninitializedConverterThrowsException()
         {
             using DataStream ds = DataStreamFactory.FromArray(_validDds, 0, _validDds.Length);
-            DdsFileFormat format = new ()
+            var format = new DdsFileFormat()
             {
                 Internal = DdsFile.Load(ds),
             };
 
-            Replace converter = new ();
+            var converter = new Replace();
 
             _ = Assert.Throws<InvalidOperationException>(() => converter.Convert(format));
         }
@@ -38,9 +38,9 @@
         public void InvalidReplacementImageThrowsException()
         {
             using DataStream ds2 = DataStreamFactory.FromArray(_invalidData, 0, _invalidData.Length);
-            BinaryFormat bf = new (ds2);
+            var bf = new BinaryFormat(ds2);
 
-            Replace converter = new ();
+            var converter = new Replace();
             _ = Assert.Throws<SixLabors.ImageSharp.UnknownImageFormatException>(() => converter.Initialize(bf));
         }
 
@@ -49,13 +49,13 @@
         {
             using DataStream ds = DataStreamFactory.FromArray(_validDds, 0, _validDds.Length);
             using DataStream ds2 = DataStreamFactory.FromArray(_validPng, 0, _validPng.Length);
-            DdsFileFormat format = new ()
+            var format = new DdsFileFormat()
             {
                 Internal = DdsFile.Load(ds),
             };
-            BinaryFormat bf = new (ds2);
+            var bf = new BinaryFormat(ds2);
 
-            Replace converter = new ();
+            var converter = new Replace();
             converter.Initialize(bf);
 
             Assert.AreEqual(8, format.Internal.header.dwWidth);

--- a/src/Tests/TF3.Tests/Converters/DdsImage/WriterTests.cs
+++ b/src/Tests/TF3.Tests/Converters/DdsImage/WriterTests.cs
@@ -14,15 +14,15 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            Writer converter = new ();
+            var converter = new Writer();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
         [Test]
         public void NullDdsThrowsException()
         {
-            Writer converter = new ();
-            DdsFileFormat format = new ();
+            var converter = new Writer();
+            var format = new DdsFileFormat();
             _ = Assert.Throws<NullReferenceException>(() => converter.Convert(format));
         }
 
@@ -30,19 +30,19 @@
         public void WriteDds()
         {
             using DataStream ds = DataStreamFactory.FromArray(_validData, 0, _validData.Length);
-            DdsFileFormat format = new ()
+            var format = new DdsFileFormat()
             {
                 Internal = DdsFile.Load(ds),
             };
 
-            Writer converter = new ();
+            var converter = new Writer();
 
             BinaryFormat result = converter.Convert(format);
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.Stream);
 
             result.Stream.Position = 0;
-            DataReader reader = new (result.Stream);
+            var reader = new DataReader(result.Stream);
             uint magic = reader.ReadUInt32();
 
             Assert.AreEqual(542327876, magic);

--- a/src/Tests/TF3.Tests/Converters/Po/NodeContainerToPoTests.cs
+++ b/src/Tests/TF3.Tests/Converters/Po/NodeContainerToPoTests.cs
@@ -13,7 +13,7 @@
         [Test]
         public void NullSourceThrowsException()
         {
-            NodeContainerToPo converter = new ();
+            var converter = new NodeContainerToPo();
             _ = Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
         }
 
@@ -22,30 +22,30 @@
         {
             byte[] data = { 0x01, 0x02, 0x03 };
             using DataStream stream = DataStreamFactory.FromArray(data, 0, 3);
-            using NodeContainerFormat format = new ();
-            using BinaryFormat binaryFormat = new (stream);
-            using Node node = new ("Node", binaryFormat);
+            using var format = new NodeContainerFormat();
+            using var binaryFormat = new BinaryFormat(stream);
+            using var node = new Node("Node", binaryFormat);
             format.Root.Add(node);
 
-            NodeContainerToPo converter = new ();
+            var converter = new NodeContainerToPo();
             _ = Assert.Throws<FormatException>(() => converter.Convert(format));
         }
 
         [Test]
         public void OnePo()
         {
-            PoHeader header = new ("testId", "reporter", "es");
-            Po po = new (header);
-            PoEntry entry = new ("Test") { Translated = "Prueba" };
+            var header = new PoHeader("testId", "reporter", "es");
+            var po = new Po(header);
+            var entry = new PoEntry("Test") { Translated = "Prueba" };
             po.Add(entry);
 
             BinaryFormat poBinary = ConvertFormat.With<Po2Binary>(po) as BinaryFormat;
 
-            using NodeContainerFormat format = new ();
-            using Node node = new ("Node", poBinary);
+            using var format = new NodeContainerFormat();
+            using var node = new Node("Node", poBinary);
             format.Root.Add(node);
 
-            NodeContainerToPo converter = new ();
+            var converter = new NodeContainerToPo();
             Po result = converter.Convert(format);
 
             Assert.IsNotNull(result);
@@ -58,26 +58,26 @@
         [Test]
         public void MultiplePo()
         {
-            PoHeader header = new ("testId", "reporter", "es");
-            Po po1 = new (header);
-            PoEntry entry1 = new ("Test 1") { Translated = "Prueba 1" };
+            var header = new PoHeader("testId", "reporter", "es");
+            var po1 = new Po(header);
+            var entry1 = new PoEntry("Test 1") { Translated = "Prueba 1" };
             po1.Add(entry1);
 
             BinaryFormat poBinary1 = ConvertFormat.With<Po2Binary>(po1) as BinaryFormat;
 
-            Po po2 = new (header);
-            PoEntry entry2 = new ("Test 2") { Translated = "Prueba 2" };
+            var po2 = new Po(header);
+            var entry2 = new PoEntry("Test 2") { Translated = "Prueba 2" };
             po2.Add(entry2);
 
             BinaryFormat poBinary2 = ConvertFormat.With<Po2Binary>(po2) as BinaryFormat;
 
-            using NodeContainerFormat format = new ();
-            using Node node1 = new ("Node 1", poBinary1);
-            using Node node2 = new ("Node 2", poBinary2);
+            using var format = new NodeContainerFormat();
+            using var node1 = new Node("Node 1", poBinary1);
+            using var node2 = new Node("Node 2", poBinary2);
             format.Root.Add(node1);
             format.Root.Add(node2);
 
-            NodeContainerToPo converter = new ();
+            var converter = new NodeContainerToPo();
             Po result = converter.Convert(format);
 
             Assert.IsNotNull(result);

--- a/src/Tests/TF3.Tests/YarhlNodeExtensionTests.cs
+++ b/src/Tests/TF3.Tests/YarhlNodeExtensionTests.cs
@@ -16,7 +16,7 @@ namespace TF3.Tests
         {
             const string parameter = "{\"Id\":\"TestParameterId\",\"TypeName\":\"System.String\",\"Value\":\"Prueba\"}";
 
-            ConverterInfo converter = new () { TypeName = "TF3.Core.Converters.FormatToSingleNode", ParameterId = "TestParameterId", };
+            var converter = new ConverterInfo() { TypeName = "TF3.Core.Converters.FormatToSingleNode", ParameterId = "TestParameterId", };
             ParameterInfo parameterInfo = JsonSerializer.Deserialize<ParameterInfo>(parameter);
 
             using Node n = NodeFactory.FromMemory("test");
@@ -29,8 +29,8 @@ namespace TF3.Tests
         [Test]
         public void MultipleConverters()
         {
-            ConverterInfo converter1 = new () { TypeName = "TF3.Core.Converters.FormatToSingleNode", ParameterId = string.Empty, };
-            ConverterInfo converter2 = new () { TypeName = "TF3.Core.Converters.SingleNodeToFormat", ParameterId = string.Empty, };
+            var converter1 = new ConverterInfo() { TypeName = "TF3.Core.Converters.FormatToSingleNode", ParameterId = string.Empty, };
+            var converter2 = new ConverterInfo() { TypeName = "TF3.Core.Converters.SingleNodeToFormat", ParameterId = string.Empty, };
             using Node n = NodeFactory.FromMemory("test");
             Assert.IsFalse(n.IsContainer);
             n.Transform(new List<ConverterInfo>() { converter1, converter2 }, new List<ParameterInfo>());
@@ -41,7 +41,7 @@ namespace TF3.Tests
         [Test]
         public void UnknownConverterThrowsException()
         {
-            ConverterInfo converter = new () { TypeName = "TF3.Core.Converters.FormatToSingleNode1", ParameterId = string.Empty, };
+            var converter = new ConverterInfo() { TypeName = "TF3.Core.Converters.FormatToSingleNode1", ParameterId = string.Empty, };
             using Node n = NodeFactory.FromMemory("test");
             Assert.Throws<UnknownConverterException>(() => n.Transform(new List<ConverterInfo>() { converter }, new List<ParameterInfo>()));
         }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="SceneGate-Preview" value="https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SceneGate-Preview">
+      <package pattern="Yarhl*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
### Description

There are containers that needs more than one file.

For example, `Trails in the Sky` games uses 2 files for each container: one as index (`.dir`) and one with the data (`.dat`). Other example is `古剑奇谭三(Gujian3)`. This game has an index file and the data is stored in several other files.

With these changes, TF3 can extract and repack multifile containers.

** **THIS IS A BREAKING CHANGE** **

The existing scripts need to be adapted.

Example. From:

```
"Path": "data/db.par",
"Checksum": 15875901786622737460,
```

To:

```
"Paths": [ "data/db.par" ],
"Checksums": [ 15875901786622737460 ],
```