### PR TITLE
Extract using node names if outputNames are unknown

### DIFF
--- a/src/Libraries/TF3.Core/GameScript.cs
+++ b/src/Libraries/TF3.Core/GameScript.cs
@@ -354,7 +354,7 @@ namespace TF3.Core
                             continue;
                         }
 
-                        string path = Path.Combine(outputPath, assetInfo.Id);
+                        string path = Path.Combine(outputPath, node.Path.Substring(1));
                         node.Stream.WriteTo(path);
                     }
                 }


### PR DESCRIPTION
### Description

Add the posibility of extracting an asset (as NodeContainerFormat) to an undeterminate number of files. It uses the children nodes paths instead the `OutputNames` property of the script.

**WARNING:**

Extracting the assets in this way does not allow to check if the asset is fully translated and relays the responsability to the plugin of giving a valid name to each node.

When rebuilding, the node order depends on the operating system and can't assure it will be the same of asset reading.

It can also lead to errors of paths exceding the operating system limit.

For all this reasons, **USE ONLY IF IT IS THE ONLY POSSIBLE SOLUTION**

### Example

For enabling, use `"OutputNames": [ "*" ]` in the script.

This closes #23
