### PR TITLE
Add configuration to publish preview packages on azure devops

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
   push:
     # Preview
-    branches: [ main ]
+    branches: [main]
     # Stable
-    tags: [ "v*" ]
+    tags: ["v*"]
   release:
     types:
       - published
 
 env:
-  NET_SDK: '6.0.x'
+  NET_SDK: "6.0.x"
 
 jobs:
   build_main:
@@ -42,7 +42,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: "Build, test and stage"
-        run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
+        run:
+          dotnet cake --target=Stage-Artifacts --configuration=Release
+          --verbosity=diagnostic
 
       - name: "Publish test results"
         uses: actions/upload-artifact@v2
@@ -65,7 +67,7 @@ jobs:
     name: "[${{ matrix.os }}] Build and test"
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
@@ -85,18 +87,20 @@ jobs:
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
-        run: dotnet cake --target=BuildTest --configuration=Release --verbosity=diagnostic
+        run:
+          dotnet cake --target=BuildTest --configuration=Release
+          --verbosity=diagnostic
 
   # Preview release on push to main only
   # Stable release on version tag push only
   push_artifacts:
     name: "Push artifacts"
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-    needs: [ "build_main", "build_sec" ]
+    needs: ["build_main", "build_sec"]
     runs-on: ubuntu-latest
     env:
       # Needed only for Azure DevOps Artifacts due to its weird auth method.
-      PREVIEW_NUGET_FEED: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
+      PREVIEW_NUGET_FEED: "https://pkgs.dev.azure.com/kaplas80/TF3/_packaging/TF3-Preview/nuget/v3/index.json"
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -119,7 +123,14 @@ jobs:
           dotnet tool restore
           dotnet cake --bootstrap
 
+      # Weird way to authenticate in Azure DevOps Artifacts
+      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
+      - name: "Install Azure Artifacts Credential Provider"
+        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
+
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          PREVIEW_NUGET_FEED_TOKEN: "az" # Dummy, auth via below env var
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.PREVIEW_NUGET_FEED_TOKEN }}"}]}'


### PR DESCRIPTION
### Description

It is useful to have the preview nuget packages in an accessible repository. Github doesn't allow public package repositories, so we are uploading to Azure Devops.

It is pending to publish stable packages to nuget.org.
