### PR TITLE
Use hex numbers in checksums

### DIFF
--- a/src/Apps/TF3.CommandLine/TF3.CommandLine.csproj
+++ b/src/Apps/TF3.CommandLine/TF3.CommandLine.csproj
@@ -14,5 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Libraries\TF3.Core\TF3.Core.csproj" />
+    <ProjectReference Include="..\..\Libraries\TF3.YarhlPlugin.Common\TF3.YarhlPlugin.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Libraries/TF3.Core/Helpers/HexStringJsonConverter.cs
+++ b/src/Libraries/TF3.Core/Helpers/HexStringJsonConverter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Luke Vo
+// Code from: https://stackoverflow.com/questions/70171426/c-sharp-json-converting-hex-literal-string-to-int
+
+namespace TF3.Core.Helpers
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Json serializer for hexadecimal numbers.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public sealed class HexStringJsonConverter : JsonConverter<ulong>
+    {
+        /// <inheritdoc/>
+        public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string value = reader.GetString();
+            return Convert.ToUInt64(value, 16);
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Helpers/HexStringListJsonConverter.cs
+++ b/src/Libraries/TF3.Core/Helpers/HexStringListJsonConverter.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Luke Vo
+// Code from: https://stackoverflow.com/questions/70171426/c-sharp-json-converting-hex-literal-string-to-int
+
+namespace TF3.Core.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Json serializer for hexadecimal number arrays.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public sealed class HexStringListJsonConverter : JsonConverter<List<ulong>>
+    {
+        /// <inheritdoc/>
+        public override List<ulong> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("Expected StartArray token");
+            }
+
+            var result = new List<ulong>();
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                string value = reader.GetString();
+                result.Add(Convert.ToUInt64(value, 16));
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, List<ulong> value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Libraries/TF3.Core/Models/ContainerInfo.cs
+++ b/src/Libraries/TF3.Core/Models/ContainerInfo.cs
@@ -22,6 +22,8 @@ namespace TF3.Core.Models
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json.Serialization;
+    using TF3.Core.Helpers;
 
     /// <summary>
     /// Game file container info.
@@ -46,8 +48,9 @@ namespace TF3.Core.Models
 
         /// <summary>
         /// Gets or sets the container checksums.
-        /// If it is 0, the file won't be checked.
+        /// If it is 0x0, the file won't be checked.
         /// </summary>
+        [JsonConverter(typeof(HexStringListJsonConverter))]
         public List<ulong> Checksums { get; set; }
 
         /// <summary>

--- a/src/Libraries/TF3.Core/Models/FileInfo.cs
+++ b/src/Libraries/TF3.Core/Models/FileInfo.cs
@@ -21,6 +21,8 @@
 namespace TF3.Core.Models
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json.Serialization;
+    using TF3.Core.Helpers;
 
     /// <summary>
     /// Game file info.
@@ -45,8 +47,9 @@ namespace TF3.Core.Models
 
         /// <summary>
         /// Gets or sets the file checksum.
-        /// If it is 0, it won't be checked.
+        /// If it is 0x0, it won't be checked.
         /// </summary>
+        [JsonConverter(typeof(HexStringJsonConverter))]
         public ulong Checksum { get; set; }
     }
 }


### PR DESCRIPTION
### Description

xxHash app shows values in hexadecimal, so it is easier to use them directly in scripts.

**BREAKING CHANGE**: Must change all the existing scripts checksums. Example:

```
"Checksums": [15875901786622737460]

"Checksum": 0
```

now are

```
"Checksums": ["0xDC52888F90A33C34"]

"Checksum": "0x0"
```
