### PR TITLE
Catch script loading exceptions

### DIFF
--- a/src/Apps/TF3.CommandLine/Program.cs
+++ b/src/Apps/TF3.CommandLine/Program.cs
@@ -36,6 +36,12 @@ namespace TF3.CommandLine
         /// <param name="args">Application arguments.</param>
         public static void Main(string[] args)
         {
+            ScriptManager.ErrorLoading += (object _, (string file, string message) x) =>
+            {
+                Console.WriteLine($"Error loading {x.file}");
+                Console.WriteLine(x.message);
+            };
+
             ScriptManager.LoadScripts("scripts");
 
             Parser.Default.ParseArguments<Options.ListScriptsOptions, Options.ExtractOptions, Options.RebuildOptions>(args)

--- a/src/Libraries/TF3.Core/ScriptManager.cs
+++ b/src/Libraries/TF3.Core/ScriptManager.cs
@@ -20,6 +20,7 @@
 
 namespace TF3.Core
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text.Json;
@@ -32,6 +33,11 @@ namespace TF3.Core
     public static class ScriptManager
     {
         private static readonly List<GameScript> _scripts = new List<GameScript>();
+
+        /// <summary>
+        /// Event triggered on errors.
+        /// </summary>
+        public static event EventHandler<(string file, string message)> ErrorLoading;
 
         /// <summary>
         /// Gets a list of loaded scripts.
@@ -54,9 +60,16 @@ namespace TF3.Core
 
             foreach (string file in Directory.EnumerateFiles(path, "TF3.Script.*.json"))
             {
-                string scriptContents = File.ReadAllText(file);
-                GameScript script = JsonSerializer.Deserialize<GameScript>(scriptContents, options);
-                _scripts.Add(script);
+                try
+                {
+                    string scriptContents = File.ReadAllText(file);
+                    GameScript script = JsonSerializer.Deserialize<GameScript>(scriptContents, options);
+                    _scripts.Add(script);
+                }
+                catch (Exception e)
+                {
+                    ErrorLoading?.Invoke(null, (file, e.Message));
+                }
             }
         }
 

--- a/src/Tests/TF3.Tests/GameScriptTests.cs
+++ b/src/Tests/TF3.Tests/GameScriptTests.cs
@@ -1,13 +1,32 @@
+// Copyright (c) 2022 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 namespace TF3.Tests
 {
     using System.IO;
-    using System.Text.Json;
     using NUnit.Framework;
 
     public class GameScriptTests
     {
-        private const string TestScript = "{\"Name\":\"test-script\",\"Game\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
-        private const string InvalidTestScript = "{\"Name\":\"test-script\",\"Game_#$\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
+        private const string TestScript = /*lang=json,strict*/ "{\"Name\":\"test-script\",\"Game\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
+        private const string InvalidTestScript = /*lang=json,strict*/ "{\"Name\":\"test-script\",\"Game_#$\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
 
         private readonly string _tempPath = Path.Combine(Path.GetTempPath(), "TF3.Tests");
 
@@ -19,7 +38,7 @@ namespace TF3.Tests
                 Directory.Delete(_tempPath, true);
             }
 
-            Directory.CreateDirectory(_tempPath);
+            _ = Directory.CreateDirectory(_tempPath);
             Core.ScriptManager.Clear();
         }
 
@@ -52,13 +71,17 @@ namespace TF3.Tests
         }
 
         [Test]
-        public void PathWithInvalidScriptsThrowsException()
+        public void PathWithInvalidScriptsCallsEvent()
         {
             string scriptPath = Path.Combine(_tempPath, "TF3.Script.Test.json");
             File.WriteAllText(scriptPath, InvalidTestScript);
 
+            int calls = 0;
+            Core.ScriptManager.ErrorLoading += (object _, (string file, string message) _) => calls++;
+
             Assert.AreEqual(0, Core.ScriptManager.Scripts.Count);
-            Assert.Throws<JsonException>(() => Core.ScriptManager.LoadScripts(_tempPath));
+            Core.ScriptManager.LoadScripts(_tempPath);
+            Assert.AreEqual(1, calls);
         }
     }
 }

--- a/src/Tests/TF3.Tests/ScriptManagerTests.cs
+++ b/src/Tests/TF3.Tests/ScriptManagerTests.cs
@@ -1,13 +1,32 @@
+// Copyright (c) 2022 Kaplas
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 namespace TF3.Tests
 {
     using System.IO;
-    using System.Text.Json;
     using NUnit.Framework;
 
     public class ScriptManagerTests
     {
-        private const string TestScript = "{\"Name\":\"test-script\",\"Game\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
-        private const string InvalidTestScript = "{\"Name\":\"test-script\",\"Game_#$\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
+        private const string TestScript = /*lang=json,strict*/ "{\"Name\":\"test-script\",\"Game\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
+        private const string InvalidTestScript = /*lang=json,strict*/ "{\"Name\":\"test-script\",\"Game_#$\":\"Test Script\",\"Parameters\":[],\"Containers\":[],\"Assets\":[],\"Patches\":[]}";
 
         private readonly string _tempPath = Path.Combine(Path.GetTempPath(), "TF3.Tests");
 
@@ -19,7 +38,7 @@ namespace TF3.Tests
                 Directory.Delete(_tempPath, true);
             }
 
-            Directory.CreateDirectory(_tempPath);
+            _ = Directory.CreateDirectory(_tempPath);
             Core.ScriptManager.Clear();
         }
 
@@ -52,13 +71,17 @@ namespace TF3.Tests
         }
 
         [Test]
-        public void PathWithInvalidScriptsThrowsException()
+        public void PathWithInvalidScriptsCallsEvent()
         {
             string scriptPath = Path.Combine(_tempPath, "TF3.Script.Test.json");
             File.WriteAllText(scriptPath, InvalidTestScript);
 
+            int calls = 0;
+            Core.ScriptManager.ErrorLoading += (object _, (string file, string message) _) => calls++;
+
             Assert.AreEqual(0, Core.ScriptManager.Scripts.Count);
-            Assert.Throws<JsonException>(() => Core.ScriptManager.LoadScripts(_tempPath));
+            Core.ScriptManager.LoadScripts(_tempPath);
+            Assert.AreEqual(1, calls);
         }
     }
 }


### PR DESCRIPTION
### Description

Before this PR, if a script was malformed, it threw an exception but didn't show the name of the failing script.

Now, it will show the script, the error message and continue loading the rest of the scripts.
