### PR TITLE
Migrate to Cake 3.0 and latest .NET SDK

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.1.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0-jammy
 
 # Install Mono (for DocFX)
 RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
-    && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel
+
+# Bug in the installation of .NET 6 in ubuntu https://github.com/dotnet/runtime/issues/79237
+ENV DOTNET_ROOT=/usr/share/dotnet

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,23 +4,27 @@
     "dockerfile": "Dockerfile"
   },
 
-  "extensions": [
-    "ms-dotnettools.csharp",
-    "shardulm94.trailing-spaces",
-    "cake-build.cake-vscode",
-    "streetsidesoftware.code-spell-checker",
-    "hediet.vscode-drawio",
-    "esbenp.prettier-vscode",
-    "yzhang.markdown-all-in-one",
-    "davidanson.vscode-markdownlint",
-    "eamodio.gitlens"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "shardulm94.trailing-spaces",
+        "cake-build.cake-vscode",
+        "streetsidesoftware.code-spell-checker",
+        "hediet.vscode-drawio",
+        "esbenp.prettier-vscode",
+        "yzhang.markdown-all-in-one",
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens"
+      ]
+    }
+  },
 
   "remoteUser": "vscode",
 
   // PODMAN ONLY. You may need to remove this line for Docker.
   // SELinux issues: https://github.com/containers/podman/issues/3683
-  "runArgs": [ "--security-opt", "label=disable", "--userns=keep-id" ],
+  // "runArgs": [ "--security-opt", "label=disable", "--userns=keep-id" ],
 
   // Podman issues: https://github.com/microsoft/vscode-remote-release/issues/3231
   "containerEnv": {

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,11 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Describe the solution you'd like to see.**

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,12 +9,9 @@ on:
     branches: [main]
     # Stable
     tags: ["v*"]
-  release:
-    types:
-      - published
 
 env:
-  NET_SDK: "6.0.x"
+  NET_SDK: "6.0.406"
 
 jobs:
   build_main:
@@ -32,19 +29,15 @@ jobs:
           dotnet-version: ${{ env.NET_SDK }}
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Build, test and stage"
-        run:
-          dotnet cake --target=Stage-Artifacts --configuration=Release
-          --verbosity=diagnostic
+        run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
 
       - name: "Publish test results"
         uses: actions/upload-artifact@v2
@@ -81,15 +74,11 @@ jobs:
           dotnet-version: ${{ env.NET_SDK }}
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
-        run:
-          dotnet cake --target=BuildTest --configuration=Release
-          --verbosity=diagnostic
+        run: dotnet cake --target=BuildTest --configuration=Release --verbosity=diagnostic
 
   # Preview release on push to main only
   # Stable release on version tag push only
@@ -119,9 +108,7 @@ jobs:
           dotnet-version: ${{ env.NET_SDK }}
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       # Weird way to authenticate in Azure DevOps Artifacts
       # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
@@ -131,6 +118,7 @@ jobs:
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
           PREVIEW_NUGET_FEED_TOKEN: "az" # Dummy, auth via below env var
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.PREVIEW_NUGET_FEED_TOKEN }}"}]}'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Cake: Run Build",
-      "program": "${workspaceFolder}/src/Apps/TF3.CommandLine/bin/Debug/net6.0/win-x64/TF3.CommandLine.dll",
+      "program": "${workspaceFolder}/src/Apps/TF3.CommandLine/bin/Debug/net6.0/linux-x64/TF3.CommandLine.dll",
       "args": [],
-      "cwd": "${workspaceFolder}/src/Apps/TF3.CommandLine/bin/Debug/net6.0/win-x64",
+      "cwd": "${workspaceFolder}/src/Apps/TF3.CommandLine/bin/Debug/net6.0/linux-x64",
       "stopAtEntry": false,
       "console": "internalConsole"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,26 +1,63 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "cake",
-			"script": "Default",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"label": "Cake: Run Default"
-		},
-		{
-			"type": "cake",
-			"script": "Build",
-			"group": "build",
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"label": "Cake: Run Build"
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Default"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=Build"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Build"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=BuildTest"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Test"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=Build",
+                "--configuration=Release"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Build for release"
+        }
+    ]
 }

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&version=0.7.0"
+#load "nuget:?package=PleOps.Cake&version=0.8.0"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/src/Apps/TF3.CommandLine/TF3.CommandLine.csproj
+++ b/src/Apps/TF3.CommandLine/TF3.CommandLine.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

Migrate to latest Cake and .NET version. This fixes issues with the CI dependencies are compiled for latest Linux OS.
